### PR TITLE
Support repeatIntervals of minute, hour, day, week, month, and year in addNotificationRequest()

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,8 @@ request is an object containing:
 - `body` : The message displayed in the notification alert.
 - `badge` The number to display as the app's icon badge. Setting the number to 0 removes the icon badge.
 - `fireDate` : The date and time when the system should deliver the notification.
-- `repeats` : Sets notification to repeat daily. Must be used with fireDate.
+- `repeats` : Sets notification to repeat (default daily). Must be used with fireDate. Use repeatInterval to modify repeat behaviour.
+- `repeatInterval`: The interval to repeat as a string. Possible values: `minute`, `hour`, `day`, `week`, `month`, `year` (optional). Default `day` if `repeats` is true. 
 - `sound` : The sound played when the notification is fired.
 - `category` : The category of this notification, required for actionable notifications.
 - `isSilent` : If true, the notification will appear without sound.

--- a/index.d.ts
+++ b/index.d.ts
@@ -175,6 +175,10 @@ export type NotificationRequest = {
    */
   repeats?: boolean;
   /**
+   * The interval to repeat as a string. Possible values: minute, hour, day, week, month, year.
+   */
+  repeatInterval?: 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';
+  /**
    * Sets notification to be silent
    */
   isSilent?: boolean;

--- a/js/types.js
+++ b/js/types.js
@@ -46,6 +46,10 @@ export type NotificationRequest = {|
    */
   repeats?: boolean,
   /**
+   * The interval to repeat as a string. Possible values: minute, hour, day, week, month, year.
+   */
+  repeatInterval?: string,
+  /**
    * Sets notification to be silent
    */
   isSilent?: boolean,


### PR DESCRIPTION
This pull request adds logic to enable `addNotificationRequest()` to have repeating logic simmilar to that provided by `scheduleLocalNotification()` which is deprecated. addNotificationRequest() now supports a `repeatInterval` parameter with values `minute`, `hour`, `day`, `week`, `month`, `year`.
This pull request also fixes a bug with `addNotificationRequest()` that meant that the notification request didn't repeat daily as documented even if the `repeats` parameter was set to `true` (it was configured in a way that meant it would only fire once).