### PR TITLE
Fix for invalid selector on iOS11

### DIFF
--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -258,7 +258,7 @@ static inline NSDictionary *RCTPromiseResolveValueForUNNotificationSettings(UNNo
   return RCTSettingsDictForUNNotificationSettings(settings.alertSetting == UNNotificationSettingEnabled,
                                                   settings.badgeSetting == UNNotificationSettingEnabled,
                                                   settings.soundSetting == UNNotificationSettingEnabled,
-                                                  settings.criticalAlertSetting == UNNotificationSettingEnabled,
+                                                  @available(iOS 12, *) && settings.criticalAlertSetting == UNNotificationSettingEnabled,
                                                   settings.lockScreenSetting == UNNotificationSettingEnabled,
                                                   settings.notificationCenterSetting == UNNotificationSettingEnabled,
                                                   settings.authorizationStatus);


### PR DESCRIPTION
Fix crash caused on iOS 11 by not supporting "criticalAlertSetting" which was added for iOS 12.