### PR TITLE
docs: unsubscribe even listeners on unmount

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,11 @@ export const App = () => {
   const [permissions, setPermissions] = useState({});
 
   useEffect(() => {
-    PushNotificationIOS.addEventListener('notification', onRemoteNotification);
+    const type = 'notification';
+    PushNotificationIOS.addEventListener(type, onRemoteNotification);
+    return () => {
+      PushNotificationIOS.removeEventListener(type);
+    };
   });
 
   const onRemoteNotification = (notification) => {
@@ -216,7 +220,11 @@ export const App = () => {
   };
 
   useEffect(() => {
-    PushNotificationIOS.addEventListener('notification', onRemoteNotification);
+    const type = 'notification';
+    PushNotificationIOS.addEventListener(type, onRemoteNotification);
+    return () => {
+      PushNotificationIOS.removeEventListener(type);
+    };
   });
 
   const onRemoteNotification = (notification) => {
@@ -234,9 +242,10 @@ export const App = () => {
   };
 };
 ```
+
 ## How to recieve rich notification in remote
 
-Follow these [article](https://firebase.google.com/docs/cloud-messaging/ios/send-image) to create rich notification for your own 
+Follow this [article](https://firebase.google.com/docs/cloud-messaging/ios/send-image) to create rich notification of your own
 
 # Reference
 
@@ -295,7 +304,7 @@ details is an object containing:
 - `isSilent` : If true, the notification will appear without sound (optional).
 - `category` : The category of this notification, required for actionable notifications (optional).
 - `userInfo` : An object containing additional notification data (optional).
-  - `image` : It's useful if you need to diplay rich notification (optional).  
+  - `image` : It's useful if you need to diplay rich notification (optional).
 - `applicationIconBadgeNumber` The number to display as the app's icon badge. Setting the number to 0 removes the icon badge (optional).
 - `repeatInterval` : The interval to repeat as a string. Possible values: `minute`, `hour`, `day`, `week`, `month`, `year` (optional).
 
@@ -412,8 +421,8 @@ Removes the specified pending notifications from Notification Center
 
 **Parameters:**
 
-| Name        | Type  | Required | Description                        |
-| ----------- | ----- | -------- | ---------------------------------- |
+| Name        | Type     | Required | Description                        |
+| ----------- | -------- | -------- | ---------------------------------- |
 | identifiers | string[] | Yes      | Array of notification identifiers. |
 
 ---
@@ -473,8 +482,8 @@ Removes the specified delivered notifications from Notification Center
 
 **Parameters:**
 
-| Name        | Type  | Required | Description                        |
-| ----------- | ----- | -------- | ---------------------------------- |
+| Name        | Type     | Required | Description                        |
+| ----------- | -------- | -------- | ---------------------------------- |
 | identifiers | string[] | Yes      | Array of notification identifiers. |
 
 ---


### PR DESCRIPTION
I "fixed" the docs so that event listeners are unregistered on unmount which makes a difference during development due to hot reloading - the listeners can get called multiple times if not handled properly, which can be confusing 😆 