### PR TITLE
parse interruptionLevel field to allow time-sensitive notifications

### DIFF
--- a/ios/RCTConvert+Notification.h
+++ b/ios/RCTConvert+Notification.h
@@ -13,6 +13,10 @@
 + (NSCalendarUnit)NSCalendarUnit:(id)json;
 @end
 
+@interface RCTConvert (UNNotificationInterruptionLevel)
++ (UNNotificationInterruptionLevel)UNNotificationInterruptionLevel:(id)json API_AVAILABLE(ios(15.0));
+@end
+
 /**
  * Type deprecated in iOS 10.0
  * TODO: This method will be removed in the next major version

--- a/ios/RCTConvert+Notification.m
+++ b/ios/RCTConvert+Notification.m
@@ -24,6 +24,20 @@ RCT_ENUM_CONVERTER(NSCalendarUnit,
 @end
 
 
+@implementation RCTConvert (UNNotificationInterruptionLevel)
+
+RCT_ENUM_CONVERTER(UNNotificationInterruptionLevel,
+                   (@{
+                      @"passive": @(UNNotificationInterruptionLevelPassive),
+                      @"active": @(UNNotificationInterruptionLevelActive),
+                      @"timeSensitive": @(UNNotificationInterruptionLevelTimeSensitive),
+                      @"critical": @(UNNotificationInterruptionLevelCritical)
+                      }),
+                   0,
+                   integerValue)
+
+@end
+
 
 /**
  * Type deprecated in iOS 10.0
@@ -105,6 +119,13 @@ RCT_ENUM_CONVERTER(UIBackgroundFetchResult, (@{
     content.body               = [RCTConvert NSString:details[@"body"]];
     content.badge              = [RCTConvert NSNumber:details[@"badge"]];
     content.categoryIdentifier = [RCTConvert NSString:details[@"category"]];
+
+    if (@available(iOS 15.0, *)) {
+        UNNotificationInterruptionLevel interruptionLevel =[RCTConvert UNNotificationInterruptionLevel:details[@"interruptionLevel"]];
+        if(interruptionLevel) {
+        content.interruptionLevel = interruptionLevel;
+        }
+    }
 
     NSString* threadIdentifier = [RCTConvert NSString:details[@"threadId"]];
     if (threadIdentifier){


### PR DESCRIPTION
iOS introduced a new feature called Focus modes in which notifications don't make a sound and don't wake up the screen unless notifications are marked time-sensitive. Notifications can be marked time-sensitive by providing an `interruptionLevel`. Added support to provide `interruptionLevel` while adding a notification request.

Fixes #345 