### PR TITLE
Make notifications time zone agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ request is an object containing:
 - `isCritical` : If true, the notification sound be played even when the device is locked, muted, or has Do Not Disturb enabled.
 - `criticalSoundVolume` : A number between 0 and 1 for volume of critical notification. Default volume will be used if not specified.
 - `userInfo` : An object containing additional notification data.
+- `isTimeZoneAgnostic` : If true, fireDate adjusted automatically upon time zone changes (e.g. for an alarm clock).
 
 request.repeatsComponent is an object containing (each field is optionnal):
 

--- a/ios/RCTConvert+Notification.m
+++ b/ios/RCTConvert+Notification.m
@@ -50,8 +50,8 @@ RCT_ENUM_CONVERTER(NSCalendarUnit,
     if (!isSilent) {
         notification.soundName = [RCTConvert NSString:details[@"soundName"]] ?: UILocalNotificationDefaultSoundName;
     }
-	if (isTimeZoneAgnostic) {
-		notification.timeZone = [NSTimeZone defaultTimeZone];
+    if (isTimeZoneAgnostic) {
+        notification.timeZone = [NSTimeZone defaultTimeZone];
 	}
     return notification;
 }

--- a/ios/RCTConvert+Notification.m
+++ b/ios/RCTConvert+Notification.m
@@ -35,6 +35,7 @@ RCT_ENUM_CONVERTER(NSCalendarUnit,
 {
     NSDictionary<NSString *, id> *details = [self NSDictionary:json];
     BOOL isSilent = [RCTConvert BOOL:details[@"isSilent"]];
+    BOOL isTimeZoneAgnostic = [RCTConvert BOOL:details[@"isTimeZoneAgnostic"]];
     UILocalNotification *notification = [UILocalNotification new];
     notification.alertTitle = [RCTConvert NSString:details[@"alertTitle"]];
     notification.fireDate = [RCTConvert NSDate:details[@"fireDate"]] ?: [NSDate date];
@@ -49,6 +50,9 @@ RCT_ENUM_CONVERTER(NSCalendarUnit,
     if (!isSilent) {
         notification.soundName = [RCTConvert NSString:details[@"soundName"]] ?: UILocalNotificationDefaultSoundName;
     }
+	if (isTimeZoneAgnostic) {
+		notification.timeZone = [NSTimeZone defaultTimeZone];
+	}
     return notification;
 }
 

--- a/ios/RCTConvert+Notification.m
+++ b/ios/RCTConvert+Notification.m
@@ -52,7 +52,7 @@ RCT_ENUM_CONVERTER(NSCalendarUnit,
     }
     if (isTimeZoneAgnostic) {
         notification.timeZone = [NSTimeZone defaultTimeZone];
-	}
+    }
     return notification;
 }
 

--- a/js/types.js
+++ b/js/types.js
@@ -74,6 +74,10 @@ export type NotificationRequest = {|
    * Optional data to be added to the notification
    */
   userInfo?: Object,
+  /**
+   * FireDate adjusted automatically upon time zone changes (e.g. for an alarm clock).
+   */
+  isTimeZoneAgnostic?: boolean,
 |};
 
 /**


### PR DESCRIPTION
This is a PR to add an optional parameter to make local notifications timezone agnostic, if a notification is scheduled for 8 pm, it will trigger at 8 pm, no matter if you are in LA or NYC. I currently have it set as "isTimeZoneAgnostic", maybe "isTimeZoneIndependent", definitely open to feedback on this. I updated the docs as well, let me know if there is anything else.