### PR TITLE
Add support for local time sensitive notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
 }
 ```
 
- And then add the following lines: 
+And then add the following lines:
 
 ```objective-c
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
@@ -339,6 +339,7 @@ request is an object containing:
 - `category` : The category of this notification, required for actionable notifications.
 - `isSilent` : If true, the notification will appear without sound.
 - `isCritical` : If true, the notification sound be played even when the device is locked, muted, or has Do Not Disturb enabled.
+- `isTimeSensitive` : (iOS 15 only) Presented immediately; Lights up screen and may play a sound; May be presented during Do Not Disturb
 - `criticalSoundVolume` : A number between 0 and 1 for volume of critical notification. Default volume will be used if not specified.
 - `userInfo` : An object containing additional notification data.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -196,6 +196,10 @@ export type NotificationRequest = {
    */
   isCritical?: boolean;
   /**
+   * Presented immediately; Lights up screen and may play a sound; May be presented during Do Not Disturb
+   */
+  isTimeSensitive?: boolean;
+  /**
    * The volume for the critical alert’s sound. Set this to a value between 0.0 (silent) and 1.0 (full volume).
    */
   criticalSoundVolume?: number;

--- a/ios/RCTConvert+Notification.m
+++ b/ios/RCTConvert+Notification.m
@@ -96,6 +96,7 @@ RCT_ENUM_CONVERTER(UIBackgroundFetchResult, (@{
 
     BOOL isSilent = [RCTConvert BOOL:details[@"isSilent"]];
     BOOL isCritical = [RCTConvert BOOL:details[@"isCritical"]];
+    BOOL isTimeSensitive = [RCTConvert BOOL:details[@"isTimeSensitive"]];
     float criticalSoundVolume = [RCTConvert float:details[@"criticalSoundVolume"]];
     NSString* identifier = [RCTConvert NSString:details[@"id"]];
 
@@ -131,6 +132,12 @@ RCT_ENUM_CONVERTER(UIBackgroundFetchResult, (@{
         } else {
             content.sound = [RCTConvert NSString:details[@"sound"]] ? [UNNotificationSound soundNamed:[RCTConvert NSString:details[@"sound"]]] : [UNNotificationSound defaultSound];
         }
+    }
+
+    if (@available(iOS 15, *)) {
+        if (isTimeSensitive) {
+            content.interruptionLevel = UNNotificationInterruptionLevelTimeSensitive;
+        } 
     }
 
     NSDate* fireDate = [RCTConvert NSDate:details[@"fireDate"]];

--- a/js/types.js
+++ b/js/types.js
@@ -67,6 +67,10 @@ export type NotificationRequest = {|
    */
   isCritical?: boolean,
   /**
+   * Sets notification to be time sensitive
+   */
+  isTimeSensitive?: boolean,
+  /**
    * The volume for the critical alert’s sound. Set this to a value between 0.0 (silent) and 1.0 (full volume).
    */
   criticalSoundVolume?: number,


### PR DESCRIPTION
Since iOS 15, iOS has had support for Time Sensitive PNs. This PR adds support by adding an optional `isTimeSensitive` boolean to the `NotificationRequest` type.

Happy to hear what the maintainers think :)

https://www.howtogeek.com/751563/what-are-time-sensitive-notifications-on-iphone/
https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/timesensitive