### PR TITLE
Replace JCenter with mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
@@ -24,7 +24,7 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -33,6 +33,5 @@ allprojects {
 
         google()
         jcenter()
-        maven { url 'https://www.jitpack.io' }
     }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:4.1.0")
@@ -32,6 +32,6 @@ allprojects {
         }
 
         google()
-        jcenter()
+        mavenCentral()
     }
 }


### PR DESCRIPTION
As JCenter has been past end of life for quite a while this PR changes build.gradle in Android by replacing JCenter with mavenCentral.

Everything works the same after this change and this package stops relying on JCenter that has regular outages.

[JCenter end of life](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)
