### PR TITLE
feat: add ability to request the device token without showing permission

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -498,6 +498,12 @@ export interface PushNotificationIOSStatic {
   ): Promise<PushNotificationPermissions>;
 
   /**
+   * Requests the APNS token for the app. This is useful for integrating with
+   * other services, such as Amazon's Simple Notification Service.
+   */
+  requestToken(): Promise<PushNotificationPermissions>;
+
+  /**
    * Unregister for all remote notifications received via Apple Push
    * Notification service.
    * You should call this method in rare circumstances only, such as when

--- a/js/index.js
+++ b/js/index.js
@@ -410,6 +410,27 @@ class PushNotificationIOS {
     return RNCPushNotificationIOS.requestPermissions(requestedPermissions);
   }
 
+    /**
+   * Requests notification permissions from iOS, prompting the user's
+   * dialog box. By default, it will request all notification permissions, but
+   * a subset of these can be requested by passing a map of requested
+   * permissions.
+   *
+   * See https://reactnative.dev/docs/pushnotificationios.html#requestpermissions
+   */
+  static requestToken(): Promise<{
+    alert: boolean,
+    badge: boolean,
+    sound: boolean,
+    critical: boolean,
+  }> {
+    invariant(
+      RNCPushNotificationIOS,
+      'PushNotificationManager is not available.',
+    );
+    return RNCPushNotificationIOS.requestToken({});
+  }
+
   /**
    * Unregister for all remote notifications received via Apple Push Notification service.
    *


### PR DESCRIPTION
# Description

Right now the only way to get the device token is to go through the permission prompt. This is not ideal if you want to support silent notification w/o asking for permission. This update allows you to achieve this.

# Docs
> If you want your app’s remote notifications to display alerts, play sounds, or perform other user-facing actions, you must request authorization to do so using the [requestAuthorization(options:completionHandler:)](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/1649527-requestauthorization) method of [UNUserNotificationCenter](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter). If you do not request and receive authorization for your app's interactions, the system delivers all remote notifications to your app silently.

