### PR TITLE
feat: add support to subscribe to/unsubscribe from a Firebase topic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -532,6 +532,18 @@ export interface PushNotificationIOSStatic {
    * Used to set specific actions for notifications that contains specified category
    */
   setNotificationCategories(categories: NotificationCategory[]): void;
+
+  /**
+   * Subscribes to the given topic (works only with Firebase).
+   * @param topic the topic
+   */
+  subscribeToTopic(topic: string): void;
+
+  /**
+   * Unsubscribes from the given topic (works only with Firebase).
+   * @param topic the topic
+   */
+  unsubscribeFromTopic(topic: string): void;
 }
 
 declare const PushNotificationIOS: PushNotificationIOSStatic;

--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -10,6 +10,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTConvert.h>
 #import <React/RCTEventDispatcher.h>
+#import <Firebase/Firebase.h>
 
 NSString *const RCTRemoteNotificationReceived = @"RemoteNotificationReceived";
 
@@ -508,6 +509,20 @@ RCT_EXPORT_METHOD(getDeliveredNotifications:(RCTResponseSenderBlock)callback)
       callback(@[formattedNotifications]);
     }];
   }
+}
+
+RCT_EXPORT_METHOD(subscribeToTopic: (NSString *)topic
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    
+  [[FIRMessaging messaging] subscribeToTopic:topic];
+}
+
+RCT_EXPORT_METHOD(unsubscribeFromTopic: (NSString *)topic
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    
+  [[FIRMessaging messaging] unsubscribeFromTopic:topic];
 }
 
 #else //TARGET_OS_TV

--- a/js/index.js
+++ b/js/index.js
@@ -457,6 +457,21 @@ class PushNotificationIOS {
   }
 
   /**
+   * Subscribes to the given topic (works only with Firebase).
+   */
+  static subscribeToTopic(topic: string) {
+    RNCPushNotificationIOS.subscribeToTopic(topic);
+  }
+
+  /**
+   * Unsubscribes from the given topic (works only with Firebase).
+   * @param topic the topic
+   */
+  static  unsubscribeFromTopic(topic: string) {
+    RNCPushNotificationIOS.unsubscribeFromTopic(topic);
+  }
+
+  /**
    * You will never need to instantiate `PushNotificationIOS` yourself.
    * Listening to the `notification` event and invoking
    * `getInitialNotification` is sufficient


### PR DESCRIPTION
The main lib https://github.com/zo0r/react-native-push-notification does offer an option to subscribe to a Firebase topic on Android. But this ios lib doesn't.

I need this functionality on ios too. Therefore, I made the necessary changes in this pull request to expose a method that allows subscribing to or unsubscribing from a Firebase topic.

Note: I set the method signature as 'fire and forget' to align with the method contract in the [main](https://github.com/zo0r/react-native-push-notification) repository.

 








