### PR TITLE
feat: add support to get fcm token

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -544,6 +544,11 @@ export interface PushNotificationIOSStatic {
    * @param topic the topic
    */
   unsubscribeFromTopic(topic: string): void;
+
+  /**
+   * Gets the FCM token for the device (works only with Firebase).
+   */
+  getFCMToken(): Promise<string>;
 }
 
 declare const PushNotificationIOS: PushNotificationIOSStatic;

--- a/index.d.ts
+++ b/index.d.ts
@@ -532,6 +532,18 @@ export interface PushNotificationIOSStatic {
    * Used to set specific actions for notifications that contains specified category
    */
   setNotificationCategories(categories: NotificationCategory[]): void;
+
+  /**
+   * Subscribes to the given topic (works only with Firebase).
+   * @param topic the topic
+   */
+  subscribeToTopic(topic: string): void;
+
+  /**
+   * Unsubscribes from the given topic (works only with Firebase).
+   * @param topic the topic
+   */
+  unsubscribeFromTopic(topic: string): void;
 }
 
 declare const PushNotificationIOS: PushNotificationIOSStatic;

--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -525,6 +525,25 @@ RCT_EXPORT_METHOD(unsubscribeFromTopic: (NSString *)topic
   [[FIRMessaging messaging] unsubscribeFromTopic:topic];
 }
 
+RCT_EXPORT_METHOD(getFCMToken:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    [[FIRMessaging messaging] tokenWithCompletion:^(NSString * _Nullable token, NSError * _Nullable error) {
+        if (error) {
+            // Handle the error, if any
+            NSLog(@"Error retrieving FCM token: %@", error.localizedDescription);
+
+            reject(@"-1", error.localizedDescription, error);
+
+        } else if (token) {
+            // FCM token successfully retrieved
+            resolve(token);
+        } else {
+            // Unable to retrieve FCM token
+            reject(@"-1", @"Error - Get FCM token failed.", error);
+        }
+    }];
+}
+
 #else //TARGET_OS_TV
 
 RCT_EXPORT_METHOD(onFinishRemoteNotification:(NSString *)notificationId fetchResult:(NSString *)fetchResult)

--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -10,6 +10,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTConvert.h>
 #import <React/RCTEventDispatcher.h>
+#import <Firebase/Firebase.h>
 
 NSString *const RCTRemoteNotificationReceived = @"RemoteNotificationReceived";
 
@@ -508,6 +509,20 @@ RCT_EXPORT_METHOD(getDeliveredNotifications:(RCTResponseSenderBlock)callback)
       callback(@[formattedNotifications]);
     }];
   }
+}
+
+RCT_EXPORT_METHOD(subscribeToTopic: (NSString *)topic
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    
+  [[FIRMessaging messaging] subscribeToTopic:topic];
+}
+
+RCT_EXPORT_METHOD(unsubscribeFromTopic: (NSString *)topic
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    
+  [[FIRMessaging messaging] unsubscribeFromTopic:topic];
 }
 
 #else //TARGET_OS_TV

--- a/js/index.js
+++ b/js/index.js
@@ -472,6 +472,13 @@ class PushNotificationIOS {
   }
 
   /**
+   * Gets the FCM token for the device (works only with Firebase).
+   */
+  static getFCMToken(): Promise<string> {
+    return RNCPushNotificationIOS.getFCMToken();
+  }
+
+  /**
    * You will never need to instantiate `PushNotificationIOS` yourself.
    * Listening to the `notification` event and invoking
    * `getInitialNotification` is sufficient

--- a/js/index.js
+++ b/js/index.js
@@ -457,6 +457,21 @@ class PushNotificationIOS {
   }
 
   /**
+   * Subscribes to the given topic (works only with Firebase).
+   */
+  static subscribeToTopic(topic: string) {
+    RNCPushNotificationIOS.subscribeToTopic(topic);
+  }
+
+  /**
+   * Unsubscribes from the given topic (works only with Firebase).
+   * @param topic the topic
+   */
+  static  unsubscribeFromTopic(topic: string) {
+    RNCPushNotificationIOS.unsubscribeFromTopic(topic);
+  }
+
+  /**
    * You will never need to instantiate `PushNotificationIOS` yourself.
    * Listening to the `notification` event and invoking
    * `getInitialNotification` is sufficient


### PR DESCRIPTION
- Implement a method to retrieve the FCM token upon request. I require this functionality in my app as I only need to obtain the FCM token once when the app is opened. I prefer not to use the onRegister method as it triggers continuously.