### PR TITLE
[typescript] Add isTimeZoneAgnostic in Typescript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -209,6 +209,10 @@ export type NotificationRequest = {
    */
   userInfo?: Record<string, any>;
   /**
+   * If true, fireDate adjusted automatically upon time zone changes (e.g. for an alarm clock).
+   */
+  isTimeZoneAgnostic?: boolean;
+  /**
    * The interruption level for the notification.
    * Possible values: 'passive', 'active', 'timeSensitive', 'critical'
    */


### PR DESCRIPTION
This was added by https://github.com/react-native-push-notification/ios/pull/354 and just didn't have updated typescript types.