### PR TITLE
fix: support userInteraction for didReceiveRemoteNotification

### DIFF
--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -140,6 +140,9 @@ API_AVAILABLE(ios(10.0)) {
   NSString *notificationId = [[NSUUID UUID] UUIDString];
   remoteNotification[@"notificationId"] = notificationId;
   remoteNotification[@"remote"] = @YES;
+  if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateInactive) {
+    remoteNotification[@"userInteraction"] = [NSNumber numberWithInt:1];
+  }
   if (completionHandler) {
     if (!self.remoteNotificationCallbacks) {
       // Lazy initialization


### PR DESCRIPTION
No matter which type of push notification (local or remote) is clicked, I expected the recommended API, didReceiveNotificationResponse, to work.
However, it's not functioning as expected some environment.(maybe firebase integration problem?)

When didReceiveNotificationResponse doesn't work, didReceiveRemoteNotification works even when the notification is clicked. 🤔
Following the [guide](https://github.com/react-native-push-notification/ios?tab=readme-ov-file#how-to-determine-push-notification-user-click), I tried to implement it, but userInteraction isn't always present.



Although it's a very hacky, the point of clicking in the background and opening the status bar to click on the push banner is considered an inactive state. So, it works using this approach.

If there's a better way, please let me know. A video is attached for reference.

https://github.com/react-native-push-notification/ios/assets/26326015/714d33d1-e886-4fe4-9206-92dbfcefeba2


