### PR TITLE
fix: add provisional notifications permissions request

### DIFF
--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -221,6 +221,10 @@ RCT_EXPORT_METHOD(requestPermissions:(NSDictionary *)permissions
         if ([RCTConvert BOOL:permissions[@"critical"]]) {
             types |= UNAuthorizationOptionCriticalAlert;
         }
+        NSInteger authStatus = [RCTConvert NSInteger:permissions[@"authorizationStatus"]];
+        if (authStatus == UNAuthorizationStatusProvisional) {
+          types |= UNAuthorizationOptionProvisional;
+        }
     }
   } else {
     types = UNAuthorizationOptionAlert | UNAuthorizationOptionBadge | UNAuthorizationOptionSound;


### PR DESCRIPTION
This PR adds the ability to request provisional notification permissions. I'm wondering why it has not been added before. Unfortunately, I couldn't get the project to build and run to test these changes. If anyone has the ability to do so or could tell me how to build and run it on an M1 mac, I'd be happy to test the changes locally. Thanks!